### PR TITLE
Add `onClick` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ The absolute path to the icon to be displayed for failure notifications. Default
 
 ![Failure](https://github.com/RoccoC/webpack-build-notifier/blob/master/icons/failure.png?raw=true "Failure")
 
+#### onClick
+What to do when the notification is clicked. By default it activates the Terminal application.
+
 Future Improvements
 -------------------
 * Re-work the notification message to display more useful information. At present, it shows the error/warning's "message" text which is not very useful as it contains inline formatting and is quite verbose. Perhaps update to instead show a list file(s) with error(s)/warning(s)?

--- a/index.js
+++ b/index.js
@@ -78,11 +78,14 @@ var WebpackBuildNotifierPlugin = function(cfg) {
      * Whether or not the last build was successful. Read-only.
      */
     this.buildSuccessful = false;
+    /**
+     * @property {Function} onClick
+     * A function called when clicking the notification. By default, it activates the Terminal application.
+     */
+    this.onClick = cfg.onClick || function(notifierObject, options) { this.activateTerminalWindow(); };
 
     // add notification click handler to activate terminal window
-    notifier.on('click', function(notifierObject, options) {
-        this.activateTerminalWindow();
-    }.bind(this));
+    notifier.on('click', this.onClick.bind(this));
 };
 
 WebpackBuildNotifierPlugin.prototype.activateTerminalWindow = function() {


### PR DESCRIPTION
I added an `onClick` option to overwrite the default behavior when clicking the notification.

For example, I'm using [`iTerm2`](https://iterm2.com) instead of the default terminal app, and I wanted to change the notifier behavior according.

I hope you could find it helpful 😉 
