### PR TITLE
Use new hooks API for webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,10 +231,19 @@ WebpackBuildNotifierPlugin.prototype.onCompilationDone = function(results) {
 };
 
 WebpackBuildNotifierPlugin.prototype.apply = function(compiler) {
-    if (!this.suppressCompileStart) {
-        compiler.plugin('watch-run', this.onCompilationWatchRun.bind(this));
+    if (compiler.hooks && compiler.hooks.watchRun && compiler.hooks.done) {
+        // for webpack >= 4
+        if (!this.suppressCompileStart) {
+            compiler.hooks.watchRun.tap('webpack-build-notifier', this.onCompilationWatchRun.bind(this));
+        }
+        compiler.hooks.done.tap('webpack-build-notifier', this.onCompilationDone.bind(this));
+    } else {
+        // for webpack < 4
+        if (!this.suppressCompileStart) {
+            compiler.plugin('watch-run', this.onCompilationWatchRun.bind(this));
+        }
+        compiler.plugin('done', this.onCompilationDone.bind(this));
     }
-    compiler.plugin('done', this.onCompilationDone.bind(this));
 };
 
 module.exports = WebpackBuildNotifierPlugin;


### PR DESCRIPTION
When I use webpack-build-notifier with webpack 4, I get the following warning:

```
(node:11724) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```

This PR removes this warning by using the new `.hooks` plugin API. However, I have made sure that it uses the deprecated API if the `.hooks` API is not present.