### PR TITLE
Fix for #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 #### 0.1.29
 ###### _August 21, 2018_
 
-- Fix for [#30](/../../issues/30)  compilation notifications no longer ignore *sound* option.
 - Fix for [#30](/../../issues/30), compilation notifications no longer ignore *sound* option.
 - Added new config option: *compilationSound*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ###### _August 21, 2018_
 
 - Fix for [#30](/../../issues/30)  compilation notifications no longer ignore *sound* option.
+- Fix for [#30](/../../issues/30), compilation notifications no longer ignore *sound* option.
 - Added new config option: *compilationSound*
 
 #### 0.1.28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+#### 0.1.29
+###### _August 21, 2018_
+
+- Fix for [#30](/../../issues/30)  compilation notifications no longer ignore *sound* option.
+- Added new config option: *compilationSound*
+
 #### 0.1.28
 ###### _June 30, 2018_
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The sound to play for warning notifications. Defaults to the value of the *sound
 #### failureSound
 The sound to play for failure notifications. Defaults to the value of the *sound* configuration option. Set to false to play no sound for failure notifications. Takes precedence over the *sound* configuration option.
 
+#### compilationSound
+The sound to play for compilation notifications. Defaults to the value of the *sound* configuration option. Set to false to play no sound for compilation notifications. Takes precedence over the *sound* configuration option.
+
 #### suppressSuccess
 Defines when success notifications are shown. Can be one of the following values:
 *  false     - Show success notification for each successful compilation (default).

--- a/index.js
+++ b/index.js
@@ -75,6 +75,12 @@ var WebpackBuildNotifierPlugin = function(cfg) {
      */
     this.failureSound = cfg.hasOwnProperty('failureSound') ? cfg.failureSound : this.sound;
     /**
+     * @cfg {String} [compilationSound='Submarine']
+     * The sound to play for compilation notifications. Defaults to the value of the *sound* configuration option.
+     * Set to false to play no sound for compilation notifications. Takes precedence over the *sound* configuration option.
+     */
+    this.compilationSound = cfg.hasOwnProperty('compilationSound') ? cfg.compilationSound : this.sound;
+    /**
      * @cfg {Boolean/String} [suppressSuccess=false]
      * Defines when success notifications are shown. Can be one of the following values:
      *   false     - Show success notification for each successful compilation (default).
@@ -195,7 +201,8 @@ WebpackBuildNotifierPlugin.prototype.onCompilationWatchRun = function(compilatio
         title: this.title,
         message: 'Compilation started...',
         contentImage: this.logo,
-        icon: this.compileIcon
+        icon: this.compileIcon,
+        sound: this.compilationSound
     });
     callback();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-build-notifier",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "A Webpack plugin that generates OS notifications for build steps using node-notifier.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes #30 and adds a new config option `compilationSound` to change/disable the compilation notification sound individually.