### PR TITLE
Added Custom callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 tests/assets
+.idea

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ The sound to play for failure notifications. Defaults to the value of the *sound
 #### compilationSound
 The sound to play for compilation notifications. Defaults to the value of the *sound* configuration option. Set to false to play no sound for compilation notifications. Takes precedence over the *sound* configuration option.
 
+#### customCallback
+The function to fire for notifications. Defaults to an empty function
+
+#### successCustomCallback
+The function to fire for success notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for success notifications. Takes precedence over the *customCallback* configuration option.
+
+#### warningCustomCallback
+The function to fire for warning notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for warning notifications. Takes precedence over the *customCallback* configuration option.
+
+#### failureCustomCallback
+The function to fire for failure notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for failure notifications. Takes precedence over the *customCallback* configuration option.
+
+#### compilationCustomCallback
+The function to fire for compilation notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for compilation notifications. Takes precedence over the *customCallback* configuration option.
+
 #### suppressSuccess
 Defines when success notifications are shown. Can be one of the following values:
 *  false     - Show success notification for each successful compilation (default).

--- a/README.md
+++ b/README.md
@@ -55,20 +55,16 @@ The sound to play for failure notifications. Defaults to the value of the *sound
 #### compilationSound
 The sound to play for compilation notifications. Defaults to the value of the *sound* configuration option. Set to false to play no sound for compilation notifications. Takes precedence over the *sound* configuration option.
 
-#### customCallback
-The function to fire for notifications. Defaults to an empty function
+#### onCompileStart
+The function to fire on compilation notifications. 
+e.g (compilation) => {} 
+compilation = webpack.compilation.Compilation
 
-#### successCustomCallback
-The function to fire for success notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for success notifications. Takes precedence over the *customCallback* configuration option.
-
-#### warningCustomCallback
-The function to fire for warning notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for warning notifications. Takes precedence over the *customCallback* configuration option.
-
-#### failureCustomCallback
-The function to fire for failure notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for failure notifications. Takes precedence over the *customCallback* configuration option.
-
-#### compilationCustomCallback
-The function to fire for compilation notifications. Defaults to the value of the *customCallback* configuration option. Set to false to not fire *customCallback* for compilation notifications. Takes precedence over the *customCallback* configuration option.
+#### onComplete
+The function to fire on completed notifications. 
+e.g (compilation, compilationResult) => {} 
+compilation = webpack.compilation.Compilation
+compilationResult = 'success' | 'error' | 'warning'
 
 #### suppressSuccess
 Defines when success notifications are shown. Can be one of the following values:

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,20 +56,24 @@ declare namespace WebpackBuildNotifierPlugin {
     customCallback?: Function;
     /**
      * The default function to be run after the success notify has fired
+     * Set to false to fire no function for success notifications. Takes precedence over the *customCallback* configuration option.
      */
-    successCustomCallback?: Function;
+    successCustomCallback?: Function | false;
     /**
      * The default function to be run after the warning notify has fired
+     * Set to false to fire no function for warning notifications. Takes precedence over the *customCallback* configuration option.
      */
-    warningCustomCallback?: Function;
+    warningCustomCallback?: Function | false;
     /**
      * The default function to be run after the failure notify has fired
+     * Set to false to fire no function for failure notifications. Takes precedence over the *customCallback* configuration option.
      */
-    failureCustomCallback?: Function;
+    failureCustomCallback?: Function | false;
     /**
      * The default function to be run after the compilation notify has fired
+     * Set to false to fire no function for compilation notifications. Takes precedence over the *customCallback* configuration option.
      */
-    compilationCustomCallback?: Function;
+    compilationCustomCallback?: Function | false;
     /**
      * Defines when success notifications are shown. Can be one of the following values:
      * 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { Plugin } from 'webpack';
 import NotificationCenter from 'node-notifier/notifiers/notificationcenter';
+import webpack = require("webpack");
 
 export = WebpackBuildNotifierPlugin;
 
@@ -15,6 +16,11 @@ declare namespace WebpackBuildNotifierPlugin {
       resource?: string;
     };
   };
+   /**
+    * String to represent valid compilation results
+    * 'success' | 'error' | 'warning'
+    */
+  type CompilationStatus = 'success' | 'error' | 'warning';
 
   type Config = {
     /**
@@ -51,29 +57,16 @@ declare namespace WebpackBuildNotifierPlugin {
      */
     compilationSound?: string | false;
     /**
-     * The default function to be run after the notify has fired
+     * The function to be run after the compile notification has fired
+     * 1. {webpack.compilation.Compilation} compilation - Compilation reference
      */
-    customCallback?: Function;
+    onCompileStart?: (compilation: webpack.compilation.Compilation) => void;
     /**
-     * The default function to be run after the success notify has fired
-     * Set to false to fire no function for success notifications. Takes precedence over the *customCallback* configuration option.
+     * The function to be run after the compile notification has fired
+     * 1. {webpack.compilation.Compilation} compilation - Compilation reference
+     * 2. {CompilationStatus} status - 'success' | 'error' | 'warning'
      */
-    successCustomCallback?: Function | false;
-    /**
-     * The default function to be run after the warning notify has fired
-     * Set to false to fire no function for warning notifications. Takes precedence over the *customCallback* configuration option.
-     */
-    warningCustomCallback?: Function | false;
-    /**
-     * The default function to be run after the failure notify has fired
-     * Set to false to fire no function for failure notifications. Takes precedence over the *customCallback* configuration option.
-     */
-    failureCustomCallback?: Function | false;
-    /**
-     * The default function to be run after the compilation notify has fired
-     * Set to false to fire no function for compilation notifications. Takes precedence over the *customCallback* configuration option.
-     */
-    compilationCustomCallback?: Function | false;
+    onComplete?: (compilation: webpack.compilation.Compilation, status: CompilationStatus) => void;
     /**
      * Defines when success notifications are shown. Can be one of the following values:
      * 

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,26 @@ declare namespace WebpackBuildNotifierPlugin {
      */
     compilationSound?: string | false;
     /**
+     * The default function to be run after the notify has fired
+     */
+    customCallback?: Function;
+    /**
+     * The default function to be run after the success notify has fired
+     */
+    successCustomCallback?: Function;
+    /**
+     * The default function to be run after the warning notify has fired
+     */
+    warningCustomCallback?: Function;
+    /**
+     * The default function to be run after the failure notify has fired
+     */
+    failureCustomCallback?: Function;
+    /**
+     * The default function to be run after the compilation notify has fired
+     */
+    compilationCustomCallback?: Function;
+    /**
      * Defines when success notifications are shown. Can be one of the following values:
      * 
      *  * `false`     - Show success notification for each successful compilation (default).

--- a/index.js
+++ b/index.js
@@ -135,23 +135,27 @@ var WebpackBuildNotifierPlugin = function(cfg) {
     /**
      * @cfg {Function} [successCustomCallback=()=>{})]
      * The function to be run after successful notifications
+     * Set to false to play no function for success notifications. Takes precedence over the *customCallback* configuration option.
      */
-    this.successCustomCallback = cfg.successCustomCallback ? cfg.successCustomCallback : this.customCallback;
+    this.successCustomCallback = cfg.hasOwnProperty('successCustomCallback') ? cfg.successCustomCallback : this.customCallback;
     /**
      * @cfg {Function} [warningCustomCallback=()=>{})]
      * The function to be run after warning notifications
+     * Set to false to play no function for warning notifications. Takes precedence over the *customCallback* configuration option.
      */
-    this.warningCustomCallback = cfg.warningCustomCallback ? cfg.warningCustomCallback : this.customCallback;
+    this.warningCustomCallback = cfg.hasOwnProperty('warningCustomCallback') ? cfg.warningCustomCallback : this.customCallback;
     /**
      * @cfg {Function} [failureCustomCallback=()=>{})]
      * The function to be run after failure notifications
+     * Set to false to play no function for failure notifications. Takes precedence over the *customCallback* configuration option.
      */
-    this.failureCustomCallback = cfg.failureCustomCallback ? cfg.failureCustomCallback : this.customCallback;
+    this.failureCustomCallback = cfg.hasOwnProperty('failureCustomCallback')? cfg.failureCustomCallback : this.customCallback;
     /**
      * @cfg {Function} [compilationCustomCallback=()=>{})]
      * The function to be run after compilation notifications
+     * Set to false to play no function for compilation notifications. Takes precedence over the *customCallback* configuration option.
      */
-    this.compilationCustomCallback = cfg.compilationCustomCallback  ? cfg.compilationCustomCallback : this.customCallback;
+    this.compilationCustomCallback = cfg.hasOwnProperty('compilationCustomCallback') ? cfg.compilationCustomCallback : this.customCallback;
     /**
      * @cfg {String} [compileIcon='./icons/compile.png']
      * The absolute path to the icon to be displayed for compilation started notifications.
@@ -236,7 +240,9 @@ WebpackBuildNotifierPlugin.prototype.onCompilationWatchRun = function(compilatio
         icon: this.compileIcon,
         sound: this.compilationSound
     });
-    this.compilationCustomCallback();
+    if (this.compilationCustomCallback) {
+        this.compilationCustomCallback();
+    }
     callback();
 };
 
@@ -288,7 +294,9 @@ WebpackBuildNotifierPlugin.prototype.onCompilationDone = function(results) {
                 wait: !buildSuccessful
             })
         );
-        customCallback();
+        if (customCallback) {
+            customCallback();
+        }
     }
 
     if (this.activateTerminalOnError && !buildSuccessful) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -35,6 +35,10 @@ describe('WebpackBuildNotifierPlugin instance test', () => {
         expect(instanceWithTitle.successSound).toBe("Submarine");
         expect(instanceWithTitle.failureSound).toBe("Submarine");
         expect(instanceWithTitle.compilationSound).toBe("Submarine");
+        expect(instanceWithTitle.customCallback).toEqual(expect.any(Function));
+        expect(instanceWithTitle.successCustomCallback).toEqual(expect.any(Function));
+        expect(instanceWithTitle.failureCustomCallback).toEqual(expect.any(Function));
+        expect(instanceWithTitle.compilationCustomCallback).toEqual(expect.any(Function));
         expect(instanceWithTitle.suppressSuccess).toBe(false);
         expect(instanceWithTitle.suppressWarning).toBe(false);
         expect(instanceWithTitle.suppressCompileStart).toBe(true);

--- a/tests/test.js
+++ b/tests/test.js
@@ -35,10 +35,8 @@ describe('WebpackBuildNotifierPlugin instance test', () => {
         expect(instanceWithTitle.successSound).toBe("Submarine");
         expect(instanceWithTitle.failureSound).toBe("Submarine");
         expect(instanceWithTitle.compilationSound).toBe("Submarine");
-        expect(instanceWithTitle.customCallback).toEqual(expect.any(Function));
-        expect(instanceWithTitle.successCustomCallback).toEqual(expect.any(Function));
-        expect(instanceWithTitle.failureCustomCallback).toEqual(expect.any(Function));
-        expect(instanceWithTitle.compilationCustomCallback).toEqual(expect.any(Function));
+        expect(instanceWithTitle.onCompileStart).toEqual(expect.any(Function));
+        expect(instanceWithTitle.onComplete).toEqual(expect.any(Function));
         expect(instanceWithTitle.suppressSuccess).toBe(false);
         expect(instanceWithTitle.suppressWarning).toBe(false);
         expect(instanceWithTitle.suppressCompileStart).toBe(true);


### PR DESCRIPTION
Hey @RoccoC !

Love the package, but i had a inkling to use custom sounds and rather than going down the routes of making another plugin for webpack just "just fire a snippet" after your code does its thing i decided to just add the ability.

Feel free to decline if this isnt something you want in your package, or you have  concerns with what ive submitted let me know and i can improve the implementation.

If you dont want this functionally no worries, i can just continue using my fork.

summary:
* add functionality to provide a base callback, and a callback per type of notification with the ability to provide overriding false if using a base callback (tried to mimic the sounds settings).
* updated tests
* updated readme

and an example of new usage playing a custom sound on complete
```
const player = require('play-sound')(opts = {});
let plugins = [];

if (processEnv.NODE_ENV === 'development') {
    plugins = plugins.concat([
        new WebpackBuildNotifierPlugin({
            title: " Build Notification",
            logo: path.join(__dirname,'src/icons/favicon.png'),
            sound: false,
            suppressCompileStart: false,
            customCallback: () => {
                player.play(path.join(__dirname,'allfinished.mp3'), (err) => {
                    if (err) console.log(err)
                });
            },
            compilationCustomCallback: false
        }),
    ]);
```

Thanks!