### PR TITLE
Add ability to customize the success message

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,15 @@ The absolute path to the icon to be displayed for compilation started notificati
 
 ![Compile](https://github.com/RoccoC/webpack-build-notifier/blob/master/src/icons/compile.png?raw=true "Compile")
 
+#### formatSuccess
+A function which returns a formatted notification message on successful compilation.
+This function must return a String.
+The default formatter will display "Build successful!".
+Note that the message will always be limited to 256 characters.
+
 #### messageFormatter
-A function which returns a formatted notification message. The function is passed 4 parameters:
+A function which returns a formatted notification message on error or warning.
+The function is passed 4 parameters:
 * {Object} error/warning - The raw error or warning object.
 * {String} filepath - The path to the file containing the error/warning (if available).
 * {CompilationStatus} status - Error or warning

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export default class WebpackBuildNotifierPlugin {
   private onComplete?: Config['onComplete'];
   private onClick: Config['onClick'] = () => this.activateTerminalWindow;
   private onTimeout?: Config['onTimeout'];
+  private formatSuccess?: Config['formatSuccess'];
   private messageFormatter?: Config['messageFormatter'];
   private notifyOptions?: Notification;
 
@@ -122,7 +123,7 @@ export default class WebpackBuildNotifierPlugin {
   private readonly onCompilationDone = (results: webpack.Stats): void => {
     let notify: boolean = false;
     let title = `${this.title} - `;
-    let msg = 'Build successful!';
+    let msg = this.formatSuccess?.() ?? 'Build successful!';
     let icon = this.successIcon;
     let sound = this.successSound;
     let compilationStatus = CompilationStatus.SUCCESS;

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,18 @@ export type Config = {
    */
   onTimeout?: (notifier: NotificationCenter, options: NotificationCenter.Notification) => void;
   /**
-   * A function which returns a formatted notification message. The function is passed 4 parameters:
+   * A function which returns a formatted notification message on successful compilation.
+   *
+   * This function must return a String.
+   *
+   * The default formatter will display "Build successful!".
+   *
+   * Note that the message will always be limited to 256 characters.
+   */
+  formatSuccess?: () => string;
+  /**
+   * A function which returns a formatted notification message on error or warning.
+   * The function is passed 4 parameters:
    *
    *  1. {CompilationResult} error/warning - The raw error or warning object.
    *  2. {string} filepath - The path to the file containing the error/warning (if available).

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export type Config = {
    *
    * Note that the message will always be limited to 256 characters.
    */
-  formatSuccess?: () => string;
+  formatSuccess?: () => string | undefined;
   /**
    * A function which returns a formatted notification message on error or warning.
    * The function is passed 4 parameters:

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -186,7 +186,7 @@ describe('Test Webpack build', () => {
       });
 
       it('Should show a success notification with a custom message', (done) => {
-        const formatSuccess = jest.fn().mockImplementation(() => 'Very nice! Great success!');
+        const formatSuccess = jest.fn(() => 'Very nice! Great success!');
         expect.assertions(2);
         webpack(getWebpackConfig({ formatSuccess }, 'success'), (err, stats) => {
           expect(formatSuccess).toHaveBeenCalled();
@@ -195,6 +195,24 @@ describe('Test Webpack build', () => {
             contentImage: undefined,
             icon: require.resolve('../src/icons/success.png'),
             message: 'Very nice! Great success!',
+            sound: 'Submarine',
+            title: 'Build Notification Test - Success',
+            wait: false,
+          });
+          done();
+        });
+      });
+
+      it('Should show default success notification message when formatSuccess returns undefined', (done) => {
+        const formatSuccess = jest.fn(() => undefined);
+        expect.assertions(2);
+        webpack(getWebpackConfig({ formatSuccess }, 'success'), (err, stats) => {
+          expect(formatSuccess).toHaveBeenCalled();
+          expect(notifier.notify).toHaveBeenCalledWith({
+            appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
+            contentImage: undefined,
+            icon: require.resolve('../src/icons/success.png'),
+            message: 'Build successful!',
             sound: 'Submarine',
             title: 'Build Notification Test - Success',
             wait: false,

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -185,6 +185,24 @@ describe('Test Webpack build', () => {
         });
       });
 
+      it('Should show a success notification with a custom message', (done) => {
+        const formatSuccess = jest.fn().mockImplementation(() => 'Very nice! Great success!');
+        expect.assertions(2);
+        webpack(getWebpackConfig({ formatSuccess }, 'success'), (err, stats) => {
+          expect(formatSuccess).toHaveBeenCalled();
+          expect(notifier.notify).toHaveBeenCalledWith({
+            appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
+            contentImage: undefined,
+            icon: require.resolve('../src/icons/success.png'),
+            message: 'Very nice! Great success!',
+            sound: 'Submarine',
+            title: 'Build Notification Test - Success',
+            wait: false,
+          });
+          done();
+        });
+      });
+
       it('Should show an error notification with a custom message', (done) => {
         const messageFormatter = jest.fn().mockImplementation(() => 'Hello, you have an error!');
         expect.assertions(2);


### PR DESCRIPTION
This allows customization like the following successful notification:

<img width="348" alt="Screen Shot 2021-04-25 at 7 46 07 PM" src="https://user-images.githubusercontent.com/113730/116013755-65baff80-a63a-11eb-917f-6ebcd7cdcf45.png">

This can be done using the following configuration:

```ts
// webpack.config.ts
import WebpackBuildNotifierPlugin from 'webpack-build-notifier';

let address: string;

export default {
  // ... snip ...
  devServer: {
    // ... snip ...
    onListening(server) {
      const { port } = server.listeningApp.address();
      address = `http://localhost:${port}`;
    },
  },
  plugins: [
    // ... snip ...
    new WebpackBuildNotifierPlugin({
      formatSuccess() {
        return address
          ? `Your application is now running at ${address}`
          : undefined; // Fallback when not running the devServer
      },
    }),
  ],
  // ... snip ...
};
```

`formatMessage` is a `() => string` function instead of a simple `string` parameter so that it can be passed a dynamic value. This is useful in cases like the example above, where the message to display depends on a value set after the plugin has been initialized.