### PR TITLE
Add compilation status and error/warning count to the error message formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ The absolute path to the icon to be displayed for compilation started notificati
 ![Compile](https://github.com/RoccoC/webpack-build-notifier/blob/master/src/icons/compile.png?raw=true "Compile")
 
 #### messageFormatter
-A function which returns a formatted notification message. The function is passed two parameters:
+A function which returns a formatted notification message. The function is passed 4 parameters:
 * {Object} error/warning - The raw error or warning object.
 * {String} filepath - The path to the file containing the error/warning (if available).
+* {CompilationStatus} status - Error or warning
+* {number} count - How many errors or warnings were raised
 
 This function must return a String.
 The default messageFormatter will display the filename which contains the error/warning followed by the

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,10 +129,12 @@ export type Config = {
    */
   onTimeout?: (notifier: NotificationCenter, options: NotificationCenter.Notification) => void;
   /**
-   * A function which returns a formatted notification message. The function is passed two parameters:
+   * A function which returns a formatted notification message. The function is passed 4 parameters:
    *
    *  1. {CompilationResult} error/warning - The raw error or warning object.
    *  2. {string} filepath - The path to the file containing the error/warning (if available).
+   *  3. {CompilationStatus} status - Error or warning
+   *  4. {number} count - How many errors or warnings were raised
    *
    * This function must return a String.
    *

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -189,7 +189,7 @@ describe('Test Webpack build', () => {
         const messageFormatter = jest.fn().mockImplementation(() => 'Hello, you have an error!');
         expect.assertions(2);
         webpack(getWebpackConfig({ messageFormatter }, 'error'), (err, stats) => {
-          expect(messageFormatter).toHaveBeenCalledWith(expect.any(Object), require.resolve('./error.js'));
+          expect(messageFormatter).toHaveBeenCalledWith(expect.any(Object), require.resolve('./error.js'), 'error', 1);
           expect(notifier.notify).toHaveBeenCalledWith({
             appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
             contentImage: undefined,
@@ -197,6 +197,24 @@ describe('Test Webpack build', () => {
             message: 'Hello, you have an error!',
             sound: 'Submarine',
             title: 'Build Notification Test - Error',
+            wait: true,
+          });
+          done();
+        });
+      });
+
+      it('Should show a warning notification with a custom message', (done) => {
+        const messageFormatter = jest.fn().mockImplementation(() => 'Hello, you have a warning!');
+        expect.assertions(2);
+        webpack(getWebpackConfig({ messageFormatter }, 'warning'), (err, stats) => {
+          expect(messageFormatter).toHaveBeenCalledWith(expect.any(Object), '', 'warning', 2);
+          expect(notifier.notify).toHaveBeenCalledWith({
+            appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
+            contentImage: undefined,
+            icon: require.resolve('../src/icons/warning.png'),
+            message: 'Hello, you have a warning!',
+            sound: 'Submarine',
+            title: 'Build Notification Test - Warning',
             wait: true,
           });
           done();


### PR DESCRIPTION
In many cases, displaying the error message is not helpful. In our case, we barely display enough of the filepath to help use figure out what is failing, so an error count would actually be a lot more concise and helpful, indicating the developer to take a look to their console.

This change allows for the following notifications:

<img width="346" alt="Screen Shot 2021-04-25 at 9 06 54 PM" src="https://user-images.githubusercontent.com/113730/116017195-9d7c7400-a647-11eb-8d6b-3c234ad8a224.png"> <img width="348" alt="Screen Shot 2021-04-25 at 9 12 39 PM" src="https://user-images.githubusercontent.com/113730/116017196-9d7c7400-a647-11eb-8e34-4b30c5a68796.png">

Using the following configuration:

```ts
// webpack.config.ts
import WebpackBuildNotifierPlugin from 'webpack-build-notifier';

let address: string;

export default {
  // ... snip ...
  plugins: [
    // ... snip ...
    new WebpackBuildNotifierPlugin({
      formatMessage(_error, _filepath, status, errorCount) {
        return `${errorCount} ${status}${errorCount === 1 ? '' : 's'}`;
      },
    }),
  ],
  // ... snip ...
};
```

This will conflict with #67 but I'm happy to rebase either PR on merge of the other one should you be happy with them :)