### PR TITLE
Allow `notifyOptions` to depend on compilation status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export default class WebpackBuildNotifierPlugin {
   private onClick: Config['onClick'] = () => this.activateTerminalWindow;
   private onTimeout?: Config['onTimeout'];
   private messageFormatter?: Config['messageFormatter'];
-  private notifyOptions?: Notification;
+  private notifyOptions?: Notification | ((status: CompilationStatus) => Notification | undefined);
 
   constructor(cfg?: Config) {
     Object.assign(this, cfg);
@@ -171,10 +171,15 @@ export default class WebpackBuildNotifierPlugin {
       this.buildSuccessful = true;
     }
 
+    const notifyOptions =
+      (typeof this.notifyOptions === 'function'
+        ? this.notifyOptions(compilationStatus)
+        : this.notifyOptions) ?? {};
+
     /* istanbul ignore else */
     if (notify) {
       notifier.notify(
-        Object.assign(this.notifyOptions || {}, {
+        Object.assign(notifyOptions, {
           title,
           sound,
           icon,

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export default class WebpackBuildNotifierPlugin {
   private onClick: Config['onClick'] = () => this.activateTerminalWindow;
   private onTimeout?: Config['onTimeout'];
   private messageFormatter?: Config['messageFormatter'];
-  private notifyOptions?: Notification | ((status: CompilationStatus) => Notification | undefined);
+  private notifyOptions?: Config['notifyOptions'];
 
   constructor(cfg?: Config) {
     Object.assign(this, cfg);

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,5 +158,8 @@ export type Config = {
    * options will be ignored, as they will be set via the corresponding {WebpackBuildNotifierConfig} options
    * (either user-specified or default).
    */
-  notifyOptions?: NotificationCenter.Notification;
+   notifyOptions?:
+     | NotificationCenter.Notification
+     | ((status: CompilationStatus) => NotificationCenter.Notification | undefined);
+
 };

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -264,5 +264,72 @@ describe('Test Webpack build', () => {
           done();
         });
       });
+
+      it('Should pass extra notifyOptions to node-notifier', (done) => {
+        expect.assertions(1);
+        webpack(getWebpackConfig({ notifyOptions: { open: 'https://example.com' } }), (err, stats) => {
+          expect(notifier.notify).toHaveBeenCalledWith({
+            appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
+            contentImage: undefined,
+            icon: require.resolve('../src/icons/success.png'),
+            message: 'Build successful!',
+            open: 'https://example.com',
+            sound: 'Submarine',
+            title: 'Build Notification Test - Success',
+            wait: false,
+          });
+          done();
+        });
+      });
+
+      it('Should execute the notifyOptions callback on success', (done) => {
+        // Override notifyOptions on successful compilation only
+        const notifyOptions = jest.fn(
+          (status: CompilationStatus) => status === CompilationStatus.SUCCESS
+            ? { open: 'https://example.com' }
+            : undefined
+        );
+
+        expect.assertions(2);
+        webpack(getWebpackConfig({ notifyOptions }), (err, stats) => {
+          expect(notifyOptions).toHaveBeenCalledWith(CompilationStatus.SUCCESS);
+          expect(notifier.notify).toHaveBeenCalledWith({
+            appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
+            contentImage: undefined,
+            icon: require.resolve('../src/icons/success.png'),
+            message: 'Build successful!',
+            open: 'https://example.com',
+            sound: 'Submarine',
+            title: 'Build Notification Test - Success',
+            wait: false,
+          });
+          done();
+        });
+      });
+
+      it('Should execute the notifyOptions callback on error', (done) => {
+        // Override notifyOptions on successful compilation only
+        const notifyOptions = jest.fn(
+          (status: CompilationStatus) => status === CompilationStatus.SUCCESS
+            ? { open: 'https://www.example.com' }
+            : undefined
+        );
+
+        expect.assertions(2);
+        webpack(getWebpackConfig({ notifyOptions }, 'error'), (err, stats) => {
+          expect(notifyOptions).toHaveBeenCalledWith(CompilationStatus.ERROR);
+          expect(notifier.notify).toHaveBeenCalledWith({
+            appName: platformName === 'Windows' ? 'Snore.DesktopToasts' : undefined,
+            contentImage: undefined,
+            icon: require.resolve('../src/icons/failure.png'),
+            message: expect.stringContaining('Module parse failed: Duplicate export \'default\''),
+            // `open` should not be set
+            sound: 'Submarine',
+            title: 'Build Notification Test - Error',
+            wait: true,
+          });
+          done();
+        });
+      });
     });
 });


### PR DESCRIPTION
This allows for the following scenario: on success, clicking the notification should open the development URL (when running the dev server); on error, clicking the notification should open the terminal window. This is only possible if evaluating `notifyOptions` dynamically when calling `notifier.notify` instead of when the plugin is instantiated.

```ts
// webpack.config.ts
import WebpackBuildNotifierPlugin from 'webpack-build-notifier';

let address: string;

export default {
  // ... snip ...
  devServer: {
    // ... snip ...
    onListening(server) {
      const { port } = server.listeningApp.address();
      address = `http://localhost:${port}`;
    },
  },
  plugins: [
    // ... snip ...
    new WebpackBuildNotifierPlugin({
      notifyOptions(success) {
        return address && status === 'success' ? { open: address } : undefined;
      },
    }),
  ],
  // ... snip ...
};
```

This is particularly useful combined with #67 as it allows us to display `Click here to open <address>` on success only and use the default error/warning message otherwise. And combined with #68, it allows for nicely readable error/warning messages as well :)