### PR TITLE
Fix incorrect `messageFormatter` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,12 @@ export type Config = {
    *
    * Note that the message will always be limited to 256 characters.
    */
-  messageFormatter?: (error: CompilationResult, filepath: string) => string;
+  messageFormatter?: (
+    error: CompilationResult,
+    filepath: string,
+    status: CompilationStatus,
+    count: number
+  ) => string;
   /**
    * Any additional node-notifier options as documented in the node-notifier documentation:
    * https://github.com/mikaelbr/node-notifier


### PR DESCRIPTION
Fixes https://github.com/RoccoC/webpack-build-notifier/pull/68

It looks like I messed up a rebase or something. Sorry!

(It would be nice if the types were not defined twice as I've hit this a couple times in my PRs. I can take a stab at consolidating them from the `Config` object if you're interested)